### PR TITLE
Add SASL support to the image. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN apk --update --no-cache add \
     shadow \
     subversion \
     tzdata \
+    cyrus-sasl \
+    cyrus-sasl-dev \
+    cyrus-sasl-digestmd5 \
   && gem install svn2git --no-ri --no-rdoc \
   && rm -rf /var/cache/apk/* /tmp/*
 


### PR DESCRIPTION
Some SVN deployments has enabled Cyrus SASL enabled and it needs some libs to be included in the image.