### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -162,8 +162,9 @@ printf "\n## Rebasing...\n"
 svn2git --rebase --authors "${authorsfile}"
 
 printf "\nTesting access to Git repository...\n"
-ssh -i "${basefolder}/id_rsa" -T git@${git_hostname}
-if [ "\$?" != "1" ]; then
+nc -zv ${git_hostname}
+ret="$?"
+if [ $ret != "0" ]; then
   rm -f ${pid_file}
   exit 1
 fi


### PR DESCRIPTION
SSH might by allowed by the host. If this is the case the ssh command returns "0" and the push is not executed. Github allows SSH, but denies shell access. Because of this, the ssh command returns 1. A call with nc should be enough, to test if port 22 is open.